### PR TITLE
Fix broken link in LibiglDownloadExternal.cmake

### DIFF
--- a/ext/libigl/cmake/LibiglDownloadExternal.cmake
+++ b/ext/libigl/cmake/LibiglDownloadExternal.cmake
@@ -50,8 +50,8 @@ endfunction()
 ## Eigen
 function(igl_download_eigen)
 	igl_download_project(eigen
-		URL           http://bitbucket.org/eigen/eigen/get/3.2.10.tar.gz
-		URL_MD5       8ad10ac703a78143a4062c9bda9d8fd3
+		URL           https://gitlab.com/libeigen/eigen/-/archive/3.2.10/eigen-3.2.10.tar.gz
+		URL_MD5       8592052beeecd890066b26c02565d548
 	)
 endfunction()
 


### PR DESCRIPTION
The ```igl_download_project``` function was using a broken bitbucket link, it now points to the new gitlab repository